### PR TITLE
Add additional environment variable for LLVM backend

### DIFF
--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -26,6 +26,7 @@ class Kframework < Formula
     ENV["SDKROOT"] = MacOS.sdk_path
     ENV["DESTDIR"] = ""
     ENV["PREFIX"] = prefix.to_s
+    ENV["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX
 
     # Unset MAKEFLAGS for `stack setup`.
     # Prevents `install: mkdir ... ghc-7.10.3/lib: File exists`


### PR DESCRIPTION
The value of `ENV["PREFIX"]` wasn't actually what I was looking for in my fix for the macOS packaging issue; this new line gets the homebrew root directory instead of the destination that K is being installed to.

I'll pair this with a matching PR to the LLVM backend to pick up the new value.