### PR TITLE
Remove use of disabled option

### DIFF
--- a/Formula/cryptopp@8.3.0.rb
+++ b/Formula/cryptopp@8.3.0.rb
@@ -3,13 +3,13 @@ class CryptoppAT830 < Formula
   homepage "https://www.cryptopp.com/"
   url "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_3_0.tar.gz"
   sha256 "63304c6f943f435a4e385273e15abb69cff3b85a44663150bf5a6069b84abd43"
-  # https://cryptopp.com/wiki/Config.h#Options_and_Defines
-  bottle :disable, "Library and clients must be built on the same microarchitecture"
+
   def install
     system "make", "shared", "all", "CXX=#{ENV.cxx}"
     system "./cryptest.exe", "v"
     system "make", "install", "PREFIX=#{prefix}"
   end
+
   test do
     (testpath/"test.cpp").write <<~EOS
       #include <cryptopp/sha.h>

--- a/Formula/cryptopp@8.3.0.rb
+++ b/Formula/cryptopp@8.3.0.rb
@@ -4,6 +4,10 @@ class CryptoppAT830 < Formula
   url "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_3_0.tar.gz"
   sha256 "63304c6f943f435a4e385273e15abb69cff3b85a44663150bf5a6069b84abd43"
 
+  pour_bottle? do
+    false
+  end
+
   def install
     system "make", "shared", "all", "CXX=#{ENV.cxx}"
     system "./cryptest.exe", "v"


### PR DESCRIPTION
As of Homebrew 3.4.0, the `cryptopp` formula is broken:
```
Error: kframework/k/cryptopp@8.3.0: Calling bottle :disable is disabled! There is no replacement.
Please report this issue to the kframework/k tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/kframework/homebrew-k/Formula/cryptopp@8.3.0.rb:7
```

This PR removes the broken usage.