### PR TITLE
Add cryptopp 8.6.0 formula for M1 mac

### DIFF
--- a/Formula/cryptopp@8.6.0.rb
+++ b/Formula/cryptopp@8.6.0.rb
@@ -1,0 +1,34 @@
+class CryptoppAT860 < Formula
+  desc "Free C++ class library of cryptographic schemes"
+  homepage "https://www.cryptopp.com/"
+  url "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"
+  sha256 "9304625f4767a13e0a5f26d0f019d78cf9375604a33e5391c3bf2e81399dfeb8"
+
+  pour_bottle? do
+    false
+  end
+
+  def install
+    system "make", "shared", "all", "CXX=#{ENV.cxx}"
+    system "./cryptest.exe", "v"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <cryptopp/sha.h>
+      #include <string>
+      using namespace CryptoPP;
+      using namespace std;
+      int main()
+      {
+        byte digest[SHA1::DIGESTSIZE];
+        string data = "Hello World!";
+        SHA1().CalculateDigest(digest, (byte*) data.c_str(), data.length());
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lcryptopp", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
The version currently in use does not support Apple Silicon; this parallel formula will allow me to test the upgrade without breaking anything currently in use.

Note that to support apple silicon, we'll probably want to move the algorand semantics onto this newer version.