### PR TITLE
Bump LLVM version required to 13

### DIFF
--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -18,7 +18,7 @@ class Kframework < Formula
   depends_on "gmp"
   depends_on "jemalloc"
   depends_on "libyaml"
-  depends_on "llvm@12"
+  depends_on "llvm@13"
   depends_on "mpfr"
   depends_on "openjdk"
   depends_on "z3"


### PR DESCRIPTION
This PR fixes a (mysterious) [code-generation issue](https://github.com/runtimeverification/k/issues/2503) that manifests as memory errors in the backend on Apple Silicon machines.

We already support LLVM 13 properly in the backend, so this change shouldn't affect any behaviour of note (other than requiring that Homebrew builds pull it in instead of 12).