### PR TITLE
Update kalgorand.rb to use cryptopp@8.6.0.rb

### DIFF
--- a/Formula/kalgorand.rb
+++ b/Formula/kalgorand.rb
@@ -14,7 +14,7 @@ class Kalgorand < Formula
   depends_on "pkg-config" => :build
   depends_on "z3" => :build
 
-  depends_on "kframework/k/cryptopp@8.3.0"
+  depends_on "kframework/k/cryptopp@8.6.0"
   depends_on "kframework/k/kframework"
 
   depends_on "boost"


### PR DESCRIPTION
This PR updates the `cryptopp` dependency in `kalgorand.rb` so that it points to the formula `cryptopp@8.6.0`, which is needed for Apple silicon support.