### PR TITLE
Drop poetry as a build requirement

### DIFF
--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -12,7 +12,6 @@ class Kframework < Formula
   depends_on "cmake" => :build
   depends_on "haskell-stack" => :build
   depends_on "maven" => :build
-  depends_on "poetry" => :build
   depends_on "pkg-config" => :build
   depends_on "bison"
   depends_on "flex"


### PR DESCRIPTION
Now that the installation method for the Python bindings has changed, we no longer require Poetry to be installed.

This is an attempt to fix the K release build, which is currently throwing errors when installing `python@3.11` as a dependency of poetry. Nothing else requires Python from K (verified with [ `brew graph`](https://github.com/martido/homebrew-graph)).