### PR TITLE
FMT is a dependency now

### DIFF
--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -15,6 +15,7 @@ class Kframework < Formula
   depends_on "pkg-config" => :build
   depends_on "bison"
   depends_on "flex"
+  depends_on "fmt"
   depends_on "gmp"
   depends_on "jemalloc"
   depends_on "libyaml"


### PR DESCRIPTION
This mirrors changes made elsewhere to include FMT as a runtime dependency for K packaging.