### PR TITLE
Hack LLVM off the `PATH` when building the haskell backend

### DIFF
--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -35,7 +35,12 @@ class Kframework < Formula
     # See also: https://github.com/brewsci/homebrew-science/blob/bb52ecc66b6f9fad4d281342139189ae81d7c410/Formula/tamarin-prover.rb#L27
     ENV.deparallelize do
       cd "haskell-backend/src/main/native/haskell-backend" do
+        # This is a hack to get LLVM off the PATH when building:
+        # https://github.com/Homebrew/homebrew-core/issues/122863
+        original_path = ENV["PATH"]
+        ENV["PATH"] = ENV["PATH"].sub "/usr/local/opt/llvm@13/bin:", ""
         system "stack", "setup"
+        ENV["PATH"] = original_path
       end
     end
 

--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -38,7 +38,7 @@ class Kframework < Formula
         # This is a hack to get LLVM off the PATH when building:
         # https://github.com/Homebrew/homebrew-core/issues/122863
         original_path = ENV["PATH"]
-        ENV["PATH"] = ENV["PATH"].sub "/usr/local/opt/llvm@13/bin:", ""
+        ENV["PATH"] = ENV["PATH"].sub "#{Formula["llvm@13"].bin}:", ""
         system "stack", "setup"
         ENV["PATH"] = original_path
       end


### PR DESCRIPTION
This is a temporary hack to get LLVM off the system PATH when building the Haskell backend; if we don't do this then a known issue in stack breaks the build: https://github.com/commercialhaskell/stack/pull/4366

I have reported the issue to Homebrew core, and will come back to fix the issue in our formula when I hear from them what the best thing to do is: https://github.com/Homebrew/homebrew-core/issues/122863

I've tested this fix in a minimal example (which consistently reproduces this issue otherwise; details all linked in the homebrew core issue above), so I'm reasonably confident this fix is correct.