### PR TITLE
Add a CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,12 @@ concurrency:
 jobs:
   install-from-source:
     name: 'Build and install K from formula'
-    runs-on: [macos-11, macos-12]
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-11, macos-12]
+
     steps:
     - name: 'Check out code'
       uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,12 +18,12 @@ jobs:
     - name: 'Check out code'
       uses: actions/checkout@v3
 
-    - name: 'Install K formula'
+    - name: 'Install K formulas'
       run: |
-        brew install              \
-          ./Formula/kframework.rb \
-          --build-from-source     \
-          --verbose
+        brew tap kframework/k file://$(pwd)
+        brew install --build-from-source cryptopp@8.3.0
+        brew install --build-from-source cryptopp@8.6.0
+        brew install --build-from-source kframework
 
     - name: 'Smoke test'
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,14 +23,16 @@ jobs:
         brew tap kframework/k file://$(pwd)
 
         brew install --build-from-source cryptopp@8.3.0
-        brew uninstall cryptopp@8.3.0
+        brew unlink cryptopp@8.3.0
 
         brew install --build-from-source cryptopp@8.6.0
-        brew uninstall cryptopp@8.6.0
+        brew unlink cryptopp@8.6.0
 
         brew install --build-from-source kframework
 
     - name: 'Smoke test'
+      env:
+        JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
       run: |
         kompile --help
         krun    --help

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,13 @@ jobs:
     - name: 'Install K formulas'
       run: |
         brew tap kframework/k file://$(pwd)
+
         brew install --build-from-source cryptopp@8.3.0
+        brew uninstall cryptopp@8.3.0
+
         brew install --build-from-source cryptopp@8.6.0
+        brew uninstall cryptopp@8.6.0
+
         brew install --build-from-source kframework
 
     - name: 'Smoke test'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,27 @@
+name: 'Test Homebrew formula'
+on:
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-from-source:
+    name: 'Build and install K from formula'
+    runs-on: [macos-11, macos-12]
+    steps:
+    - name: 'Check out code'
+      uses: actions/checkout@v3
+
+    - name: 'Install K formula'
+      run: |
+        brew install              \
+          ./Formula/kframework.rb \
+          --build-from-source     \
+          --verbose
+
+    - name: 'Smoke test'
+      run: |
+        kompile --help
+        krun    --help
+        kprove  --help

--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -37,10 +37,9 @@ class Kframework < Formula
       cd "haskell-backend/src/main/native/haskell-backend" do
         # This is a hack to get LLVM off the PATH when building:
         # https://github.com/Homebrew/homebrew-core/issues/122863
-        original_path = ENV["PATH"]
-        ENV["PATH"] = ENV["PATH"].sub "#{Formula["llvm@13"].bin}:", ""
-        system "stack", "setup"
-        ENV["PATH"] = original_path
+        with_env(PATH: ENV["PATH"].sub("#{Formula["llvm@13"].bin}:", "")) do
+          system "stack", "setup"
+        end
       end
     end
 


### PR DESCRIPTION
This sets up a CI workflow to build and install the K formula when changes are made to this repository; this isn't very frequent usually but I've had to make a couple of changes recently and having CI would have saved some time in local testing.

It also includes a small cleanup suggested in this homebrew core issue: https://github.com/Homebrew/homebrew-core/issues/122863

@F-WRunTime if you're happy with the workflow, the checks will also need to be added to the PR required list.