### PR TITLE
Pass maven options through homebrew filter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,13 +27,13 @@ jobs:
       run: |
         brew tap kframework/k file://$(pwd)
 
-        brew install --build-from-source cryptopp@8.3.0
+        brew install --build-from-source --verbose cryptopp@8.3.0
         brew unlink cryptopp@8.3.0
 
-        brew install --build-from-source cryptopp@8.6.0
+        brew install --build-from-source --verbosecryptopp@8.6.0 
         brew unlink cryptopp@8.6.0
 
-        brew install --build-from-source kframework
+        brew install --build-from-source --verbose kframework 
 
     - name: 'Smoke test'
       env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,13 +27,13 @@ jobs:
       run: |
         brew tap kframework/k file://$(pwd)
 
+        brew install --build-from-source --verbose kframework 
+
         brew install --build-from-source --verbose cryptopp@8.3.0
         brew unlink cryptopp@8.3.0
 
         brew install --build-from-source --verbose cryptopp@8.6.0 
         brew unlink cryptopp@8.6.0
-
-        brew install --build-from-source --verbose kframework 
 
     - name: 'Smoke test'
       env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         brew install --build-from-source --verbose cryptopp@8.3.0
         brew unlink cryptopp@8.3.0
 
-        brew install --build-from-source --verbosecryptopp@8.6.0 
+        brew install --build-from-source --verbose cryptopp@8.6.0 
         brew unlink cryptopp@8.6.0
 
         brew install --build-from-source --verbose kframework 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,11 +19,6 @@ jobs:
       uses: actions/checkout@v3
 
     - name: 'Install K formulas'
-      env:
-        HOMEBREW_MAVEN_OPTS: >-
-            -Dhttp.keepAlive=false
-            -Dmaven.wagon.http.pool=false
-            -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
       run: |
         brew tap kframework/k file://$(pwd)
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,11 @@ jobs:
       uses: actions/checkout@v3
 
     - name: 'Install K formulas'
+      env:
+        HOMEBREW_MAVEN_OPTS: >-
+            -Dhttp.keepAlive=false
+            -Dmaven.wagon.http.pool=false
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
       run: |
         brew tap kframework/k file://$(pwd)
 

--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -29,7 +29,7 @@ class Kframework < Formula
     ENV["DESTDIR"] = ""
     ENV["PREFIX"] = prefix.to_s
     ENV["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX
-    ENV["MAVEN_OPTS"] = ENV["HOMEBREW_MAVEN_OPTS"]
+    # ENV["MAVEN_OPTS"] = ENV["HOMEBREW_MAVEN_OPTS"]
 
     # Unset MAKEFLAGS for `stack setup`.
     # Prevents `install: mkdir ... ghc-7.10.3/lib: File exists`
@@ -44,7 +44,7 @@ class Kframework < Formula
       end
     end
 
-    system "mvn", "package", "-DskipTests", "-Dproject.build.type=FastBuild", "-Dhttp.keepAlive=false", "-Dmaven.wagon.http.pool=false", "-Dmaven.wagon.httpconnectionManager.ttlSeconds=30"
+    system "mvn", "package", "-DskipTests", "-Dproject.build.type=FastBuild", "-Dmaven.wagon.httpconnectionManager.ttlSeconds=30"
     system "package/package"
   end
 

--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -44,7 +44,7 @@ class Kframework < Formula
       end
     end
 
-    system "mvn", "package", "-DskipTests", "-Dproject.build.type=FastBuild"
+    system "mvn", "package", "-DskipTests", "-Dproject.build.type=FastBuild", "-Dhttp.keepAlive=false", "-Dmaven.wagon.http.pool=false", "-Dmaven.wagon.httpconnectionManager.ttlSeconds=30"
     system "package/package"
   end
 

--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -29,7 +29,6 @@ class Kframework < Formula
     ENV["DESTDIR"] = ""
     ENV["PREFIX"] = prefix.to_s
     ENV["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX
-    # ENV["MAVEN_OPTS"] = ENV["HOMEBREW_MAVEN_OPTS"]
 
     # Unset MAKEFLAGS for `stack setup`.
     # Prevents `install: mkdir ... ghc-7.10.3/lib: File exists`
@@ -42,6 +41,8 @@ class Kframework < Formula
           system "stack", "setup"
         end
 
+        # Build the Haskell backend before running maven so that our connections
+        # don't time out.
         system "stack", "build"
       end
     end

--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -29,6 +29,7 @@ class Kframework < Formula
     ENV["DESTDIR"] = ""
     ENV["PREFIX"] = prefix.to_s
     ENV["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX
+    ENV["MAVEN_OPTS"] = ENV["HOMEBREW_MAVEN_OPTS"]
 
     # Unset MAKEFLAGS for `stack setup`.
     # Prevents `install: mkdir ... ghc-7.10.3/lib: File exists`

--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -41,6 +41,8 @@ class Kframework < Formula
         with_env(PATH: ENV["PATH"].sub("#{Formula["llvm@13"].bin}:", "")) do
           system "stack", "setup"
         end
+
+        system "stack", "build"
       end
     end
 


### PR DESCRIPTION
Homebrew filters any environment variables that don't begin with `HOMEBREW_`, so to pass any `MAVEN_OPTS` we want to use in CI, we have to perform this passthrough step.

Will be followed up with a K PR that passes some extra Maven opts when building this formula in CI.