### PR TITLE
Bump macOS versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12, macos-13]
 
     steps:
     - name: 'Check out code'


### PR DESCRIPTION
Related to https://github.com/runtimeverification/k/pull/3697, we are moving from macOS 11 -> 13 in CI; 11 is now sufficiently old that we can drop it from our CI process for the K Homebrew bottle.