### PR TITLE
add missing dependency for newer versions of k

### DIFF
--- a/Formula/kframework.rb
+++ b/Formula/kframework.rb
@@ -22,6 +22,7 @@ class Kframework < Formula
   depends_on "llvm@13"
   depends_on "mpfr"
   depends_on "openjdk"
+  depends_on "secp256k1"
   depends_on "z3"
 
   def install


### PR DESCRIPTION
This dependency will be required in future versions of K because the Haskell backend now requires it. We are updating the brew formula file in advance of that fact so that the release won't break when it becomes required.